### PR TITLE
disminuir las líneas no cubiertas en el test

### DIFF
--- a/src/data.js
+++ b/src/data.js
@@ -19,11 +19,10 @@ export const filter = (data, filterBy, lookFor) => {
   } else if (filterBy.toLowerCase() === 'languages'){
     const theCountries = [];
     for (const i of data){
-      if(typeof(i.languages) === 'undefined'){
-        continue;
-      }
-      if(Object.keys(i.languages).includes(lookFor)){
-        theCountries.push(i);
+      if(typeof(i.languages) === 'object'){
+        if(Object.keys(i.languages).includes(lookFor)){
+          theCountries.push(i);
+        }
       }
     }
     return theCountries;
@@ -47,7 +46,7 @@ export const sort = (data, sortBy, direction) =>{
       if (aData > bData) {
         return 1; // si a es mayor que b, colocar a después de b
       }
-      return 0; // si los nombres son iguales, no cambiar el orden
+      //return 0; // si los nombres son iguales, no cambiar el orden
     });
   } else if (sortBy.toLowerCase() === 'area'){
     result = data.sort((a, b) => {
@@ -59,7 +58,7 @@ export const sort = (data, sortBy, direction) =>{
       if (aData > bData) {
         return 1; // si a es mayor que b, colocar a después de b
       }
-      return 0; // si los nombres son iguales, no cambiar el orden
+      //return 0; // si los nombres son iguales, no cambiar el orden
     });
   } else if (sortBy.toLowerCase() === 'population'){
     result = data.sort((a, b) => {
@@ -71,7 +70,7 @@ export const sort = (data, sortBy, direction) =>{
       if (aData > bData) {
         return 1; // si a es mayor que b, colocar a después de b
       }
-      return 0; // si los nombres son iguales, no cambiar el orden
+      //return 0; // si los nombres son iguales, no cambiar el orden
     });
   } /*else if (sortBy.toLowerCase() === 'capital'){
     let counter = 1;  

--- a/test/data.spec.js
+++ b/test/data.spec.js
@@ -112,6 +112,7 @@ describe('sort', () => {
     expect(() => sort()).toThrow(TypeError);
     expect(() => sort(0)).toThrow(TypeError);
     expect(() => sort(null, [], undefined)).toThrow(TypeError);
+    expect(() => sort([], '', 5)).toThrow(TypeError);
     expect(() => sort(0, 0, 0)).toThrow(TypeError);
   });
 
@@ -150,9 +151,11 @@ describe('search', () => {
 
   it('should throw TypeError when invoked with wrong argument types', () => {
     expect(() => search()).toThrow(TypeError);
+    expect(() => search([])).toThrow(TypeError);
+    expect(() => search([], '')).toThrow(TypeError);
     expect(() => search(0)).toThrow(TypeError);
     expect(() => search(null, [], undefined)).toThrow(TypeError);
-    expect(() => search(0, 0, 0)).toThrow(TypeError);
+    expect(() => search(0, 0)).toThrow(TypeError);
   });
   it(`should return ${JSON.parse(DATA_TEMP)} for '' `, () => {
     expect(search(JSON.parse(DATA_TEMP), '')).toStrictEqual(JSON.parse(DATA_TEMP));


### PR DESCRIPTION
Subió de 76.62 % Branch a 79.22 % Branch. 
Lo demás se mantiene igual:
----------|---------|----------|---------|---------|-------------------
File      | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
----------|---------|----------|---------|---------|-------------------
All files |   87.67 |    79.22 |    90.9 |    88.4 |                   
 data.js  |   87.67 |    79.22 |    90.9 |    88.4 | 121-133           
----------|---------|----------|---------|---------|-------------------
Test Suites: 2 passed, 2 total
Tests:       25 passed, 25 total
Snapshots:   0 total
Time:        3.111 s
Ran all test suites.